### PR TITLE
Re-design Redux store 

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -6,7 +6,7 @@ import { Dispatch } from 'redux';
 export const RASTERS_FETCHED = 'RASTERS_FETCHED';
 export const RASTER_SELECTED = 'RASTER_SELECTED';
 
-export const BASKET_ADDED = 'BASKET_ADDED';
+export const BASKET_UPDATED = 'BASKET_UPDATED';
 
 const rastersFetched = (apiObject: APIObject): RastersFetched => ({
     type: RASTERS_FETCHED,
@@ -31,11 +31,11 @@ export const selectRaster = (uuid: string, dispatch: Dispatch<RasterSelected>): 
     dispatch(rasterSelected(uuid));
 };
 
-const basketAdded = (basket: string[]):BasketAdded => ({
-    type: BASKET_ADDED,
+const basketUpdated = (basket: string[]):BasketAdded => ({
+    type: BASKET_UPDATED,
     payload: basket
 });
 
-export const addToBasket = (basket: string[], dispatch: Dispatch<BasketAdded>): void => {
-    dispatch(basketAdded(basket))
+export const updateBasket = (basket: string[], dispatch: Dispatch<BasketAdded>): void => {
+    dispatch(basketUpdated(basket))
 };

--- a/src/action.ts
+++ b/src/action.ts
@@ -1,6 +1,6 @@
 import request from 'superagent';
 import { baseUrl } from './api';
-import { RastersFetched, RasterSelected, RastersObject, Raster } from './interface';
+import { RastersFetched, RasterSelected, APIObject, BasketAdded } from './interface';
 import { Dispatch } from 'redux';
 
 export const RASTERS_FETCHED = 'RASTERS_FETCHED';
@@ -8,9 +8,9 @@ export const RASTER_SELECTED = 'RASTER_SELECTED';
 
 export const BASKET_ADDED = 'BASKET_ADDED';
 
-const rastersFetched = (rasters: RastersObject): RastersFetched => ({
+const rastersFetched = (apiObject: APIObject): RastersFetched => ({
     type: RASTERS_FETCHED,
-    payload: rasters
+    payload: apiObject
 });
 
 export const fetchRasters = (page: number, searchTerm: string, dispatch: Dispatch<RastersFetched>): void => {
@@ -22,20 +22,20 @@ export const fetchRasters = (page: number, searchTerm: string, dispatch: Dispatc
         .catch(console.error)
 };
 
-const rasterSelected = (raster: Raster): RasterSelected => ({
+const rasterSelected = (uuid: string): RasterSelected => ({
     type: RASTER_SELECTED,
-    payload: raster
+    payload: uuid
 });
 
-export const selectRaster = (raster: Raster, dispatch: Dispatch<RasterSelected>): void => {
-    dispatch(rasterSelected(raster));
+export const selectRaster = (uuid: string, dispatch: Dispatch<RasterSelected>): void => {
+    dispatch(rasterSelected(uuid));
 };
 
-const basketAdded = (basket) => ({
+const basketAdded = (basket: string[]):BasketAdded => ({
     type: BASKET_ADDED,
     payload: basket
 });
 
-export const addToBasket = (basket, dispatch) => {
+export const addToBasket = (basket: string[], dispatch: Dispatch<BasketAdded>): void => {
     dispatch(basketAdded(basket))
 };

--- a/src/components/RasterContainer.tsx
+++ b/src/components/RasterContainer.tsx
@@ -1,21 +1,21 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { fetchRasters, selectRaster, addToBasket } from '../action';
-import { getRaster, getRastersObject, MyStore, getRasters } from '../reducers';
+import { MyStore, getRasterUuid, getRasterAPI, getAllRasters } from '../reducers';
 import RasterList from './RasterList';
 import RasterDetails from './RasterDetails';
-import { RasterActionType, RastersObject, Raster } from '../interface';
+import { RasterActionType } from '../interface';
 import { Dispatch } from 'redux';
 import './Raster.css';
 
 interface PropsFromState {
-  rastersObject: RastersObject | null;
-  raster: Raster | null;
-  rasters: {};
+  rasterAPI: MyStore['rasterAPI'] | null;
+  allRasters: MyStore['allRasters'];
+  uuid: string | null;
 }
 
 interface PropsFromDispatch {
-  selectRaster: (raster: Raster) => void;
+  selectRaster: (uuid: string) => void;
   fetchRasters: (page: number, searchTerm: string) => void;
   addToBasket: (basket) => void;
 };
@@ -65,16 +65,17 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
         return (
             <div className="raster-container">
                 <RasterList 
-                    rastersObject={this.props.rastersObject} 
-                    selectRaster={this.props.selectRaster} 
-                    page={this.state.page} 
                     searchTerm={this.state.searchTerm}
+                    page={this.state.page} 
+                    rasterAPI={this.props.rasterAPI}
+                    allRasters={this.props.allRasters}
+                    selectRaster={this.props.selectRaster}
+                    addToBasket={this.props.addToBasket} 
                     onClick={this.onClick}
                     onChange={this.onChange}
                     onSubmit={this.onSubmit}
-                    addToBasket={this.props.addToBasket}
                 />
-                <RasterDetails raster={this.props.raster} />
+                <RasterDetails uuid={this.props.uuid} allRasters={this.props.allRasters} />
             </div>
         );
     };
@@ -82,15 +83,15 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
 
 const mapStateToProps = (state: MyStore): PropsFromState => {
     return {
-      rastersObject: getRastersObject(state),
-      raster: getRaster(state),
-      rasters: getRasters(state)
-    }
+      rasterAPI: getRasterAPI(state),
+      uuid: getRasterUuid(state),
+      allRasters: getAllRasters(state)
+    };
 };
 
 const mapDispatchToProps = (dispatch: Dispatch<RasterActionType>): PropsFromDispatch => ({
     fetchRasters: (page: number, searchTerm: string) => fetchRasters(page, searchTerm, dispatch),
-    selectRaster: (raster: Raster) => selectRaster(raster, dispatch),
+    selectRaster: (uuid: string) => selectRaster(uuid, dispatch),
     addToBasket: (basket) => addToBasket(basket, dispatch)
 });
 

--- a/src/components/RasterContainer.tsx
+++ b/src/components/RasterContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { fetchRasters, selectRaster, addToBasket } from '../action';
-import { MyStore, getRasterUuid, getRasterAPI, getAllRasters } from '../reducers';
+import { fetchRasters, selectRaster, updateBasket } from '../action';
+import { MyStore, getAllRasters, getCurrentRasterList, getRaster } from '../reducers';
 import RasterList from './RasterList';
 import RasterDetails from './RasterDetails';
 import { RasterActionType } from '../interface';
@@ -9,15 +9,15 @@ import { Dispatch } from 'redux';
 import './Raster.css';
 
 interface PropsFromState {
-  rasterAPI: MyStore['rasterAPI'] | null;
+  currentRasterList: MyStore['currentRasterList'] | null;
   allRasters: MyStore['allRasters'];
-  uuid: string | null;
+  selectedRaster: string | null;
 }
 
 interface PropsFromDispatch {
   selectRaster: (uuid: string) => void;
   fetchRasters: (page: number, searchTerm: string) => void;
-  addToBasket: (basket) => void;
+  updateBasket: (basket) => void;
 };
 
 type RasterContainerProps = PropsFromState & PropsFromDispatch;
@@ -67,15 +67,15 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
                 <RasterList 
                     searchTerm={this.state.searchTerm}
                     page={this.state.page} 
-                    rasterAPI={this.props.rasterAPI}
+                    currentRasterList={this.props.currentRasterList}
                     allRasters={this.props.allRasters}
                     selectRaster={this.props.selectRaster}
-                    addToBasket={this.props.addToBasket} 
+                    updateBasket={this.props.updateBasket} 
                     onClick={this.onClick}
                     onChange={this.onChange}
                     onSubmit={this.onSubmit}
                 />
-                <RasterDetails uuid={this.props.uuid} allRasters={this.props.allRasters} />
+                <RasterDetails selectedRaster={this.props.selectedRaster} allRasters={this.props.allRasters} />
             </div>
         );
     };
@@ -83,8 +83,8 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
 
 const mapStateToProps = (state: MyStore): PropsFromState => {
     return {
-      rasterAPI: getRasterAPI(state),
-      uuid: getRasterUuid(state),
+      currentRasterList: getCurrentRasterList(state),
+      selectedRaster: getRaster(state),
       allRasters: getAllRasters(state)
     };
 };
@@ -92,7 +92,7 @@ const mapStateToProps = (state: MyStore): PropsFromState => {
 const mapDispatchToProps = (dispatch: Dispatch<RasterActionType>): PropsFromDispatch => ({
     fetchRasters: (page: number, searchTerm: string) => fetchRasters(page, searchTerm, dispatch),
     selectRaster: (uuid: string) => selectRaster(uuid, dispatch),
-    addToBasket: (basket) => addToBasket(basket, dispatch)
+    updateBasket: (basket) => updateBasket(basket, dispatch)
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(RasterContainer);

--- a/src/components/RasterContainer.tsx
+++ b/src/components/RasterContainer.tsx
@@ -9,15 +9,15 @@ import { Dispatch } from 'redux';
 import './Raster.css';
 
 interface PropsFromState {
-  currentRasterList: MyStore['currentRasterList'] | null;
-  allRasters: MyStore['allRasters'];
-  selectedRaster: string | null;
-}
+    currentRasterList: MyStore['currentRasterList'] | null;
+    allRasters: MyStore['allRasters'];
+    selectedRaster: string | null;
+};
 
 interface PropsFromDispatch {
-  selectRaster: (uuid: string) => void;
-  fetchRasters: (page: number, searchTerm: string) => void;
-  updateBasket: (basket) => void;
+    selectRaster: (uuid: string) => void;
+    fetchRasters: (page: number, searchTerm: string) => void;
+    updateBasket: (basket) => void;
 };
 
 type RasterContainerProps = PropsFromState & PropsFromDispatch;
@@ -64,16 +64,17 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
     render() {
         return (
             <div className="raster-container">
-                <RasterList 
+                <RasterList
                     searchTerm={this.state.searchTerm}
-                    page={this.state.page} 
+                    page={this.state.page}
                     currentRasterList={this.props.currentRasterList}
                     allRasters={this.props.allRasters}
                     selectRaster={this.props.selectRaster}
-                    updateBasket={this.props.updateBasket} 
+                    updateBasket={this.props.updateBasket}
                     onClick={this.onClick}
                     onChange={this.onChange}
                     onSubmit={this.onSubmit}
+                    rasters2={[]}
                 />
                 <RasterDetails selectedRaster={this.props.selectedRaster} allRasters={this.props.allRasters} />
             </div>
@@ -81,13 +82,11 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
     };
 };
 
-const mapStateToProps = (state: MyStore): PropsFromState => {
-    return {
-      currentRasterList: getCurrentRasterList(state),
-      selectedRaster: getRaster(state),
-      allRasters: getAllRasters(state)
-    };
-};
+const mapStateToProps = (state: MyStore): PropsFromState => ({
+    currentRasterList: getCurrentRasterList(state),
+    selectedRaster: getRaster(state),
+    allRasters: getAllRasters(state)
+});
 
 const mapDispatchToProps = (dispatch: Dispatch<RasterActionType>): PropsFromDispatch => ({
     fetchRasters: (page: number, searchTerm: string) => fetchRasters(page, searchTerm, dispatch),

--- a/src/components/RasterContainer.tsx
+++ b/src/components/RasterContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { fetchRasters, selectRaster, updateBasket } from '../action';
-import { MyStore, getAllRasters, getCurrentRasterList, getRaster } from '../reducers';
+import { MyStore, getCurrentRasterList } from '../reducers';
 import RasterList from './RasterList';
 import RasterDetails from './RasterDetails';
 import { RasterActionType } from '../interface';
@@ -10,8 +10,6 @@ import './Raster.css';
 
 interface PropsFromState {
     currentRasterList: MyStore['currentRasterList'] | null;
-    allRasters: MyStore['allRasters'];
-    selectedRaster: string | null;
 };
 
 interface PropsFromDispatch {
@@ -68,24 +66,20 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
                     searchTerm={this.state.searchTerm}
                     page={this.state.page}
                     currentRasterList={this.props.currentRasterList}
-                    allRasters={this.props.allRasters}
                     selectRaster={this.props.selectRaster}
                     updateBasket={this.props.updateBasket}
                     onClick={this.onClick}
                     onChange={this.onChange}
                     onSubmit={this.onSubmit}
-                    rasters2={[]}
                 />
-                <RasterDetails selectedRaster={this.props.selectedRaster} allRasters={this.props.allRasters} />
+                <RasterDetails />
             </div>
         );
     };
 };
 
 const mapStateToProps = (state: MyStore): PropsFromState => ({
-    currentRasterList: getCurrentRasterList(state),
-    selectedRaster: getRaster(state),
-    allRasters: getAllRasters(state)
+    currentRasterList: getCurrentRasterList(state)
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<RasterActionType>): PropsFromDispatch => ({

--- a/src/components/RasterDetails.tsx
+++ b/src/components/RasterDetails.tsx
@@ -1,102 +1,110 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { Map, TileLayer, WMSTileLayer } from 'react-leaflet';
-import { MyStore } from '../reducers';
+import { MyStore, getRaster } from '../reducers';
 import { Raster } from '../interface';
 import './RasterDetails.css';
 
-interface MyProps {
-    selectedRaster: string | null;
-    allRasters: MyStore['allRasters'];
-}
-
-const RasterDetails = (props: MyProps) => {
-    //Destructure the props
-    const { selectedRaster, allRasters } = props;
-
-    //If no raster is selected, display a text
-    if (!selectedRaster) return <div className="raster-details raster-details__loading">Please select a raster</div>;
-
-    //Assign the raster object based on the uuid of the raster
-    const raster: Raster = allRasters[selectedRaster];
-
-    //Set the Map with bounds coming from spatial_bounds of the Raster
-    const { north, east, south, west } = raster.spatial_bounds;
-    const bounds = [[north, east], [south, west]];
-
-    //Get the Date from the timestamp string
-    const startDate = new Date(raster.first_value_timestamp);
-    const stopDate = new Date(raster.last_value_timestamp);
-
-    //Turn the new Date into a string with the date format of DD-MM-YYYY
-    const start = startDate.toLocaleDateString();
-    const stop = stopDate.toLocaleDateString();
-
-    //Calculate raster resolution and decide to show it in m2 or square degrees
-    const rasterResolution = Math.abs(raster.pixelsize_x * raster.pixelsize_y);
-    //If the projection is EPSG:4326, the resolution is calculated in square degrees, otherwise it is in m2
-    const resolution = raster.projection === "EPSG:4326" ? rasterResolution.toFixed(6) + " deg2" : rasterResolution + " m2"
-
-    return (
-        <div className="raster-details">
-            <h3>{raster.name}</h3>
-            <span className="raster-details__uuid">{raster.uuid}</span>
-            <div className="raster-details__main-box">
-                <div className="raster-details__description-box">
-                    <h4>Description</h4>
-                    <span>{raster.description}</span>
-                    <br/>
-                    <h4>Organisation</h4>
-                    <span>{raster.organisation.name}</span>
-                </div>
-                <div className="raster-details__map-box">
-                    <Map bounds={bounds} >
-                        <TileLayer url="https://{s}.tiles.mapbox.com/v3/nelenschuurmans.iaa98k8k/{z}/{x}/{y}.png" />
-                        <WMSTileLayer url={raster.wms_info.endpoint} layers={raster.wms_info.layer} />
-                    </Map>
-                </div>
-            </div>
-            <div className="raster-details__data-1">
-                <div className="row">
-                    <p className="column column-1">Temporal</p><p className="column column-2">{raster.temporal ? 'Yes' : 'No'} </p>
-                </div>
-                <div className="row">
-                    <p className="column column-1">Resolution</p><p className="column column-2">{resolution}</p>
-                </div>
-                <div className="row">
-                    <p className="column column-1">Datatype</p><p className="column column-2">Raster</p>
-                </div>
-                <div className="row">
-                    <p className="column column-1">Interval</p><p className="column column-2">{raster.temporal ? raster.interval : null}</p>
-                </div>
-                <div className="row">
-                    <p className="column column-1">Start</p><p className="column column-2">{raster.temporal ? start : null}</p>
-                </div>
-                <div className="row">
-                    <p className="column column-1">Stop</p><p className="column column-2">{raster.temporal ? stop : null}</p>
-                </div>
-            </div>
-            <br />
-            <div className="raster-details__data-2">
-                <div className="row">
-                    <p className="column column-1">Observation type</p><p className="column column-2">{raster.observation_type.parameter}</p>
-                </div>
-                <div className="row">
-                    <p className="column column-1">Measuring unit</p><p className="column column-2">{raster.observation_type.unit}</p>
-                </div>
-                <div className="row">
-                    <p className="column column-1">Scale</p><p className="column column-2">{raster.observation_type.scale}</p>
-                </div>
-            </div>
-            <br/>
-            <div className="raster-details__button-container">
-                <h4>View data in</h4>
-                <div>
-                    <button className="raster-details__button button-api" onClick={() => window.location.href = `https://demo.lizard.net/api/v4/rasters/${raster.uuid}`}>API</button>
-                    <button className="raster-details__button button-lizard" onClick={() => window.location.href = `https://demo.lizard.net`}>LIZARD</button>
-                </div>
-            </div>
-        </div>
-    );
+interface PropsFromState {
+    raster: Raster | null;
 };
 
-export default RasterDetails;
+class RasterDetails extends React.Component<PropsFromState> {
+    render() {
+        //Destructure the props
+        const { raster } = this.props;
+
+        //If no raster is selected, display a text
+        if (!raster) return <div className="raster-details raster-details__loading">Please select a raster</div>;
+
+        //Set the Map with bounds coming from spatial_bounds of the Raster
+        const { north, east, south, west } = raster.spatial_bounds;
+        const bounds = [[north, east], [south, west]];
+
+        //Get the Date from the timestamp string
+        const startDate = new Date(raster.first_value_timestamp);
+        const stopDate = new Date(raster.last_value_timestamp);
+
+        //Turn the new Date into a string with the date format of DD-MM-YYYY
+        const start = startDate.toLocaleDateString();
+        const stop = stopDate.toLocaleDateString();
+
+        //Calculate raster resolution and decide to show it in m2 or square degrees
+        const rasterResolution = Math.abs(raster.pixelsize_x * raster.pixelsize_y);
+        //If the projection is EPSG:4326, the resolution is calculated in square degrees, otherwise it is in m2
+        const resolution = raster.projection === "EPSG:4326" ? rasterResolution.toFixed(6) + " deg2" : rasterResolution + " m2"
+
+        return (
+            <div className="raster-details">
+                <h3>{raster.name}</h3>
+                <span className="raster-details__uuid">{raster.uuid}</span>
+                <div className="raster-details__main-box">
+                    <div className="raster-details__description-box">
+                        <h4>Description</h4>
+                        <span>{raster.description}</span>
+                        <br/>
+                        <h4>Organisation</h4>
+                        <span>{raster.organisation.name}</span>
+                    </div>
+                    <div className="raster-details__map-box">
+                        <Map bounds={bounds} >
+                            <TileLayer url="https://{s}.tiles.mapbox.com/v3/nelenschuurmans.iaa98k8k/{z}/{x}/{y}.png" />
+                            <WMSTileLayer url={raster.wms_info.endpoint} layers={raster.wms_info.layer} />
+                        </Map>
+                    </div>
+                </div>
+                <div className="raster-details__data-1">
+                    <div className="row">
+                        <p className="column column-1">Temporal</p><p className="column column-2">{raster.temporal ? 'Yes' : 'No'} </p>
+                    </div>
+                    <div className="row">
+                        <p className="column column-1">Resolution</p><p className="column column-2">{resolution}</p>
+                    </div>
+                    <div className="row">
+                        <p className="column column-1">Datatype</p><p className="column column-2">Raster</p>
+                    </div>
+                    <div className="row">
+                        <p className="column column-1">Interval</p><p className="column column-2">{raster.temporal ? raster.interval : null}</p>
+                    </div>
+                    <div className="row">
+                        <p className="column column-1">Start</p><p className="column column-2">{raster.temporal ? start : null}</p>
+                    </div>
+                    <div className="row">
+                        <p className="column column-1">Stop</p><p className="column column-2">{raster.temporal ? stop : null}</p>
+                    </div>
+                </div>
+                <br />
+                <div className="raster-details__data-2">
+                    <div className="row">
+                        <p className="column column-1">Observation type</p><p className="column column-2">{raster.observation_type.parameter}</p>
+                    </div>
+                    <div className="row">
+                        <p className="column column-1">Measuring unit</p><p className="column column-2">{raster.observation_type.unit}</p>
+                    </div>
+                    <div className="row">
+                        <p className="column column-1">Scale</p><p className="column column-2">{raster.observation_type.scale}</p>
+                    </div>
+                </div>
+                <br/>
+                <div className="raster-details__button-container">
+                    <h4>View data in</h4>
+                    <div>
+                        <button className="raster-details__button button-api" onClick={() => window.location.href = `https://demo.lizard.net/api/v4/rasters/${raster.uuid}`}>API</button>
+                        <button className="raster-details__button button-lizard" onClick={() => window.location.href = `https://demo.lizard.net`}>LIZARD</button>
+                    </div>
+                </div>
+            </div>
+        );
+    };    
+};
+
+const mapStateToProps = (state: MyStore): PropsFromState => {
+    if (!state.selectedRaster) return {
+        raster: null 
+    };
+    return {
+        raster: getRaster(state, state.selectedRaster)
+    };
+};
+
+export default connect(mapStateToProps)(RasterDetails);

--- a/src/components/RasterDetails.tsx
+++ b/src/components/RasterDetails.tsx
@@ -1,19 +1,23 @@
 import * as React from 'react';
-// import { Raster } from '../interface';
 import { Map, TileLayer, WMSTileLayer } from 'react-leaflet';
-
-import './RasterDetails.css';
+import { MyStore } from '../reducers';
 import { Raster } from '../interface';
+import './RasterDetails.css';
 
 interface MyProps {
-    raster: Raster | null;
+    uuid: string | null;
+    allRasters: MyStore['allRasters'];
 }
 
 const RasterDetails = (props: MyProps) => {
+    //Destructure the props
+    const { uuid, allRasters } = props;
 
-    const { raster } = props;
+    //If no raster is selected, display a text
+    if (!uuid) return <div className="raster-details raster-details__loading">Please select a raster</div>;
 
-    if (!raster) return <div className="raster-details raster-details__loading">Please select a raster</div>;
+    //Assign the raster object based on the uuid of the raster
+    const raster: Raster = allRasters[uuid];
 
     //Set the Map with bounds coming from spatial_bounds of the Raster
     const { north, east, south, west } = raster.spatial_bounds;

--- a/src/components/RasterDetails.tsx
+++ b/src/components/RasterDetails.tsx
@@ -5,19 +5,19 @@ import { Raster } from '../interface';
 import './RasterDetails.css';
 
 interface MyProps {
-    uuid: string | null;
+    selectedRaster: string | null;
     allRasters: MyStore['allRasters'];
 }
 
 const RasterDetails = (props: MyProps) => {
     //Destructure the props
-    const { uuid, allRasters } = props;
+    const { selectedRaster, allRasters } = props;
 
     //If no raster is selected, display a text
-    if (!uuid) return <div className="raster-details raster-details__loading">Please select a raster</div>;
+    if (!selectedRaster) return <div className="raster-details raster-details__loading">Please select a raster</div>;
 
     //Assign the raster object based on the uuid of the raster
-    const raster: Raster = allRasters[uuid];
+    const raster: Raster = allRasters[selectedRaster];
 
     //Set the Map with bounds coming from spatial_bounds of the Raster
     const { north, east, south, west } = raster.spatial_bounds;

--- a/src/components/RasterList.tsx
+++ b/src/components/RasterList.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
+import { connect } from 'react-redux';
 import { Raster } from '../interface';
 import './RasterList.css';
-import { MyStore } from '../reducers';
+import { MyStore, getRasterObject } from '../reducers';
 
 interface MyProps {
     page: number;
@@ -13,6 +14,7 @@ interface MyProps {
 
     currentRasterList: MyStore['currentRasterList'] | null;
     allRasters: MyStore['allRasters'];
+    rasters2: Raster[] | [];
 
     selectRaster: (uuid: string) => void;
     updateBasket: (basket) => void;
@@ -40,7 +42,7 @@ class RasterList extends React.Component<MyProps, MyState> {
             //If already selected then remove this uuid from the basket
             this.setState({
                 checkedRaster: this.state.checkedRaster.filter(id => id !== uuid)
-             });
+            });
         };
     };
 
@@ -54,8 +56,12 @@ class RasterList extends React.Component<MyProps, MyState> {
         //Destructure rasterAPI object
         const { count, previous, next, rasterList } = currentRasterList;
 
-        //Create a new array of Arrays based on the rasterList array of all raster uuids
-        const rasters = rasterList.map(uuid => allRasters[uuid])
+        //Assign the rasters props to a variable
+        const rasters3 = rasterList.map(uuid => allRasters[uuid])
+        const rasters = this.props.rasters2
+
+        console.log(rasters)
+        console.log(rasters3)
 
         return (
             <div className="raster-list">
@@ -90,7 +96,7 @@ class RasterList extends React.Component<MyProps, MyState> {
 
                             return (
                                 <li className="raster-list__row-li" key={raster.uuid} onClick={() => selectRaster(raster.uuid)} >
-                                    <input className="raster-list__row raster-list__row-box" type="checkbox" onClick={() => this.onCheckboxSelect(raster.uuid)} defaultChecked={checked}/>
+                                    <input className="raster-list__row raster-list__row-box" type="checkbox" onClick={() => this.onCheckboxSelect(raster.uuid)} defaultChecked={checked} />
                                     <div className="raster-list__row raster-list__row-type">#</div>
                                     <div className="raster-list__row raster-list__row-name">{raster.name}</div>
                                     <div className="raster-list__row raster-list__row-org">{raster.organisation.name}</div>
@@ -117,4 +123,11 @@ class RasterList extends React.Component<MyProps, MyState> {
     }
 };
 
-export default RasterList;
+const mapStateToProps = (state: MyStore, ownProps: MyProps) => {
+    if (!ownProps.currentRasterList) return null
+    return {
+        rasters2: ownProps.currentRasterList.rasterList.map(uuid => getRasterObject(state, uuid))
+    }
+}
+
+export default connect(mapStateToProps)(RasterList);

--- a/src/components/RasterList.tsx
+++ b/src/components/RasterList.tsx
@@ -1,40 +1,61 @@
 import * as React from 'react';
-import { Raster, RastersObject } from '../interface';
+import { Raster } from '../interface';
 import './RasterList.css';
+import { MyStore } from '../reducers';
 
 interface MyProps {
-    rastersObject: RastersObject | null;
-    selectRaster: (raster: Raster) => void;
     page: number;
     searchTerm: string;
+
     onClick: (page: number) => void;
     onChange: (event: object) => void;
     onSubmit: (event: object) => void;
+
+    rasterAPI: MyStore['rasterAPI'] | null;
+    allRasters: MyStore['allRasters'];
+
+    selectRaster: (uuid: string) => void;
     addToBasket: (basket) => void;
-}
+};
 
-class RasterList extends React.Component<MyProps, {}> {
-    state = {};
+interface MyState {
+    basket: string[];
+};
 
-    onCheckboxSelect = (raster: Raster) => {
-        if (!this.state[raster.uuid]) {
+class RasterList extends React.Component<MyProps, MyState> {
+    state = {
+        basket: []
+    };
+
+    onCheckboxSelect = (uuid: string) => {
+        //Check if the raster has already been selected or not
+        const selectedUuid = this.state.basket.filter(id => id === uuid)
+
+        //If not yet selected then add this new uuid into the basket
+        if (selectedUuid.length === 0) {
             this.setState({
-                [raster.uuid]: raster
+                basket: [...this.state.basket, uuid]
             });
         } else {
-            delete this.state[raster.uuid];
-            this.setState({});
+            //If already selected then remove this uuid from the basket
+            this.setState({
+                basket: this.state.basket.filter(id => id !== uuid)
+             });
         };
     };
 
     render() {
-        console.log(this.state)
-        const { rastersObject, selectRaster, page, searchTerm, onClick, onChange, onSubmit, addToBasket } = this.props;
+        //Destructure all props of the Raster List component
+        const { searchTerm, page, onClick, onChange, onSubmit, rasterAPI, allRasters, selectRaster, addToBasket } = this.props;
 
-        if (!rastersObject) return <div className="raster-list"><h1>Loading ...</h1></div>;
+        //If nothing is fetched, Loading ... sign appeears
+        if (!rasterAPI) return <div className="raster-list"><h1>Loading ...</h1></div>;
 
-        const { count, previous, next } = rastersObject;
-        const rasters = rastersObject.results;
+        //Destructure rasterAPI object
+        const { count, previous, next, rasterList } = rasterAPI;
+
+        //Create a new array of Arrays based on the rasterList array of all raster uuids
+        const rasters = rasterList.map(uuid => allRasters[uuid])
 
         return (
             <div className="raster-list">
@@ -65,12 +86,11 @@ class RasterList extends React.Component<MyProps, {}> {
                             //Here is a logic to define whether a raster has been selected (check-box has been checked or not)
                             //if yes then the default checked value of the input field will be true
                             //if no then the default checked value of the input field will be false
-                            const rasterUuid = this.state[raster.uuid];
-                            const checked = rasterUuid ? true : false;
+                            const checked = this.state.basket.filter(uuid => uuid === raster.uuid).length === 0 ? false : true;
 
                             return (
-                                <li className="raster-list__row-li" key={raster.uuid} onClick={() => selectRaster(raster)} >
-                                    <input className="raster-list__row raster-list__row-box" type="checkbox" onClick={() => this.onCheckboxSelect(raster)} defaultChecked={checked} />
+                                <li className="raster-list__row-li" key={raster.uuid} onClick={() => selectRaster(raster.uuid)} >
+                                    <input className="raster-list__row raster-list__row-box" type="checkbox" onClick={() => this.onCheckboxSelect(raster.uuid)} defaultChecked={checked}/>
                                     <div className="raster-list__row raster-list__row-type">#</div>
                                     <div className="raster-list__row raster-list__row-name">{raster.name}</div>
                                     <div className="raster-list__row raster-list__row-org">{raster.organisation.name}</div>
@@ -87,7 +107,7 @@ class RasterList extends React.Component<MyProps, {}> {
                     </div>
                 </div>
                 <div className="raster-list__button-container">
-                    {Object.keys(this.state).length === 0 ?
+                    {this.state.basket.length === 0 ?
                         <button className="raster-list__button raster-list__button-grey">ADD TO BASKET</button> :
                         <button className="raster-list__button" onClick={() => addToBasket(this.state)}>ADD TO BASKET</button>
                     }

--- a/src/components/RasterList.tsx
+++ b/src/components/RasterList.tsx
@@ -11,48 +11,48 @@ interface MyProps {
     onChange: (event: object) => void;
     onSubmit: (event: object) => void;
 
-    rasterAPI: MyStore['rasterAPI'] | null;
+    currentRasterList: MyStore['currentRasterList'] | null;
     allRasters: MyStore['allRasters'];
 
     selectRaster: (uuid: string) => void;
-    addToBasket: (basket) => void;
+    updateBasket: (basket) => void;
 };
 
 interface MyState {
-    basket: string[];
+    checkedRaster: string[];
 };
 
 class RasterList extends React.Component<MyProps, MyState> {
     state = {
-        basket: []
+        checkedRaster: []
     };
 
     onCheckboxSelect = (uuid: string) => {
         //Check if the raster has already been selected or not
-        const selectedUuid = this.state.basket.filter(id => id === uuid)
+        const selectedUuid = this.state.checkedRaster.filter(id => id === uuid)
 
         //If not yet selected then add this new uuid into the basket
         if (selectedUuid.length === 0) {
             this.setState({
-                basket: [...this.state.basket, uuid]
+                checkedRaster: [...this.state.checkedRaster, uuid]
             });
         } else {
             //If already selected then remove this uuid from the basket
             this.setState({
-                basket: this.state.basket.filter(id => id !== uuid)
+                checkedRaster: this.state.checkedRaster.filter(id => id !== uuid)
              });
         };
     };
 
     render() {
         //Destructure all props of the Raster List component
-        const { searchTerm, page, onClick, onChange, onSubmit, rasterAPI, allRasters, selectRaster, addToBasket } = this.props;
+        const { searchTerm, page, onClick, onChange, onSubmit, currentRasterList, allRasters, selectRaster, updateBasket } = this.props;
 
         //If nothing is fetched, Loading ... sign appeears
-        if (!rasterAPI) return <div className="raster-list"><h1>Loading ...</h1></div>;
+        if (!currentRasterList) return <div className="raster-list"><h1>Loading ...</h1></div>;
 
         //Destructure rasterAPI object
-        const { count, previous, next, rasterList } = rasterAPI;
+        const { count, previous, next, rasterList } = currentRasterList;
 
         //Create a new array of Arrays based on the rasterList array of all raster uuids
         const rasters = rasterList.map(uuid => allRasters[uuid])
@@ -86,7 +86,7 @@ class RasterList extends React.Component<MyProps, MyState> {
                             //Here is a logic to define whether a raster has been selected (check-box has been checked or not)
                             //if yes then the default checked value of the input field will be true
                             //if no then the default checked value of the input field will be false
-                            const checked = this.state.basket.filter(uuid => uuid === raster.uuid).length === 0 ? false : true;
+                            const checked = this.state.checkedRaster.filter(uuid => uuid === raster.uuid).length === 0 ? false : true;
 
                             return (
                                 <li className="raster-list__row-li" key={raster.uuid} onClick={() => selectRaster(raster.uuid)} >
@@ -107,9 +107,9 @@ class RasterList extends React.Component<MyProps, MyState> {
                     </div>
                 </div>
                 <div className="raster-list__button-container">
-                    {this.state.basket.length === 0 ?
+                    {this.state.checkedRaster.length === 0 ?
                         <button className="raster-list__button raster-list__button-grey">ADD TO BASKET</button> :
-                        <button className="raster-list__button" onClick={() => addToBasket(this.state)}>ADD TO BASKET</button>
+                        <button className="raster-list__button" onClick={() => updateBasket(this.state.checkedRaster)}>ADD TO BASKET</button>
                     }
                 </div>
             </div>

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,20 +1,25 @@
-import { RASTERS_FETCHED, RASTER_SELECTED } from "./action";
+import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_ADDED } from "./action";
 
 //ACTION INTERFACE
 export interface RastersFetched {
     type: typeof RASTERS_FETCHED;
-    payload: RastersObject;
+    payload: APIObject;
 };
 
 export interface RasterSelected {
     type: typeof RASTER_SELECTED;
-    payload: Raster;
+    payload: string;
 };
 
-export type RasterActionType = RastersFetched | RasterSelected;
+export interface BasketAdded {
+    type: typeof BASKET_ADDED;
+    payload: string[];
+}
+
+export type RasterActionType = RastersFetched | RasterSelected | BasketAdded;
 
 //INTERFACES
-export interface RastersObject {
+export interface APIObject {
     count: number;
     previous: string;
     next: string;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -1,4 +1,4 @@
-import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_ADDED } from "./action";
+import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_UPDATED } from "./action";
 
 //ACTION INTERFACE
 export interface RastersFetched {
@@ -12,7 +12,7 @@ export interface RasterSelected {
 };
 
 export interface BasketAdded {
-    type: typeof BASKET_ADDED;
+    type: typeof BASKET_UPDATED;
     payload: string[];
 }
 

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -1,5 +1,5 @@
 import { combineReducers } from 'redux';
-import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_UPDATED } from "./action";
+import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_UPDATED } from './action';
 import { RastersFetched, RasterSelected, Raster, BasketAdded } from './interface';
 
 export interface MyStore {
@@ -66,12 +66,8 @@ export const getCurrentRasterList = (state: MyStore) => {
     return state.currentRasterList;
 };
 
-export const getAllRasters = (state: MyStore) => {
-    return state.allRasters;
-}
-
-export const getRaster = (state: MyStore) => {
-    return state.selectedRaster;
+export const getRaster = (state: MyStore, uuid: string) => {
+    return state.allRasters[uuid];
 };
 
 export default combineReducers({
@@ -80,8 +76,3 @@ export default combineReducers({
     selectedRaster,
     basket
 });
-
-//TEST:
-export const getRasterObject = (state: MyStore, uuid: string) => {
-    return state.allRasters[uuid];
-};

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -80,3 +80,8 @@ export default combineReducers({
     selectedRaster,
     basket
 });
+
+//TEST:
+export const getRasterObject = (state: MyStore, uuid: string) => {
+    return state.allRasters[uuid];
+};

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -1,9 +1,9 @@
 import { combineReducers } from 'redux';
-import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_ADDED } from "./action";
+import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_UPDATED } from "./action";
 import { RastersFetched, RasterSelected, Raster, BasketAdded } from './interface';
 
 export interface MyStore {
-    rasterAPI: {
+    currentRasterList: {
         count: number;
         previous: string | null;
         next: string | null;
@@ -12,11 +12,11 @@ export interface MyStore {
     allRasters: {
         [index: string]: Raster;
     } | {};
-    uuid: string | null;
+    selectedRaster: string | null;
     basket: string[];
 };
 
-const rasterAPI = (state: MyStore['rasterAPI'] = null, action: RastersFetched) => {
+const currentRasterList = (state: MyStore['currentRasterList'] = null, action: RastersFetched) => {
     switch (action.type) {
         case RASTERS_FETCHED:
             const { count, previous, next } = action.payload;
@@ -44,7 +44,7 @@ const allRasters = (state: MyStore['allRasters'] = {}, action: RastersFetched) =
     };
 };
 
-const uuid = (state: MyStore['uuid'] = null, action: RasterSelected) => {
+const selectedRaster = (state: MyStore['selectedRaster'] = null, action: RasterSelected) => {
     switch (action.type) {
         case RASTER_SELECTED:
             return action.payload;
@@ -55,28 +55,28 @@ const uuid = (state: MyStore['uuid'] = null, action: RasterSelected) => {
 
 const basket = (state: MyStore['basket'] = [], action: BasketAdded) => {
     switch (action.type) {
-        case BASKET_ADDED:
+        case BASKET_UPDATED:
             return action.payload;
         default:
             return state;
     };
 };
 
-export const getRasterAPI = (state: MyStore) => {
-    return state.rasterAPI;
+export const getCurrentRasterList = (state: MyStore) => {
+    return state.currentRasterList;
 };
 
 export const getAllRasters = (state: MyStore) => {
     return state.allRasters;
 }
 
-export const getRasterUuid = (state: MyStore) => {
-    return state.uuid;
+export const getRaster = (state: MyStore) => {
+    return state.selectedRaster;
 };
 
 export default combineReducers({
-    rasterAPI,
+    currentRasterList,
     allRasters,
-    uuid,
+    selectedRaster,
     basket
 });

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -1,37 +1,40 @@
 import { combineReducers } from 'redux';
 import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_ADDED } from "./action";
-import { RastersFetched, RasterSelected, RastersObject, Raster } from './interface';
+import { RastersFetched, RasterSelected, Raster, BasketAdded } from './interface';
 
 export interface MyStore {
-    rastersObject: RastersObject | null;
-    uuid: [];
-    rasters: {};
-    selectedRaster: Raster | null;
-    basket: {};
+    rasterAPI: {
+        count: number;
+        previous: string | null;
+        next: string | null;
+        rasterList: string[];
+    } | null;
+    allRasters: {
+        [index: string]: Raster;
+    } | {};
+    uuid: string | null;
+    basket: string[];
 };
 
-const rastersObject = (state: MyStore['rastersObject'] = null, action: RastersFetched) => {
+const rasterAPI = (state: MyStore['rasterAPI'] = null, action: RastersFetched) => {
     switch (action.type) {
         case RASTERS_FETCHED:
-            return action.payload;
+            const { count, previous, next } = action.payload;
+            return {
+                count: count,
+                previous: previous,
+                next: next,
+                rasterList: action.payload.results.map(raster => raster.uuid)
+            };
         default:
             return state;
     };
 };
 
-const uuid = (state: MyStore['uuid'] = [], action: RastersFetched) => {
+const allRasters = (state: MyStore['allRasters'] = {}, action: RastersFetched) => {
     switch (action.type) {
         case RASTERS_FETCHED:
-            return action.payload.results.map(raster => raster.uuid);
-        default:
-            return state;
-    };
-};
-
-const rasters = (state: MyStore['rasters'] = {}, action: RastersFetched) => {
-    switch (action.type) {
-        case RASTERS_FETCHED:
-            const newState = {};
+            const newState = {...state};
             action.payload.results.forEach(raster => {
                 newState[raster.uuid] = raster;
             });
@@ -41,7 +44,7 @@ const rasters = (state: MyStore['rasters'] = {}, action: RastersFetched) => {
     };
 };
 
-const selectedRaster = (state: MyStore['selectedRaster'] = null, action: RasterSelected) => {
+const uuid = (state: MyStore['uuid'] = null, action: RasterSelected) => {
     switch (action.type) {
         case RASTER_SELECTED:
             return action.payload;
@@ -50,7 +53,7 @@ const selectedRaster = (state: MyStore['selectedRaster'] = null, action: RasterS
     };
 };
 
-const basket = (state: MyStore['basket'] = {}, action) => {
+const basket = (state: MyStore['basket'] = [], action: BasketAdded) => {
     switch (action.type) {
         case BASKET_ADDED:
             return action.payload;
@@ -59,22 +62,21 @@ const basket = (state: MyStore['basket'] = {}, action) => {
     };
 };
 
-export const getRastersObject = (state: MyStore) => {
-    return state.rastersObject;
+export const getRasterAPI = (state: MyStore) => {
+    return state.rasterAPI;
 };
 
-export const getRasters = (state: MyStore) => {
-    return state.rasters;
-};
+export const getAllRasters = (state: MyStore) => {
+    return state.allRasters;
+}
 
-export const getRaster = (state: MyStore) => {
-    return state.selectedRaster;
+export const getRasterUuid = (state: MyStore) => {
+    return state.uuid;
 };
 
 export default combineReducers({
-    rastersObject,
+    rasterAPI,
+    allRasters,
     uuid,
-    rasters,
-    selectedRaster,
     basket
 });


### PR DESCRIPTION
Overview of this pull request: 

Redesign Redux store with following states:
- rasterAPI: object get from the API with rasterList is an array of uuid;
- allRasters: object of {uuid: Raster, ...}
- uuid: uuid of the selected Raster
- basket: an array of uuid of rasters that are added to the basket 