### PR TITLE
Filtering feature when selecting an organisation

### DIFF
--- a/src/action.ts
+++ b/src/action.ts
@@ -17,9 +17,9 @@ const rastersFetched = (rasterListObject: RasterListObject): RastersFetched => (
     payload: rasterListObject
 });
 
-export const fetchRasters = (page: number, searchTerm: string, dispatch: Dispatch<RastersFetched>): void => {
+export const fetchRasters = (page: number, searchTerm: string, organisationName: string, dispatch: Dispatch<RastersFetched>): void => {
     request
-        .get(`${baseUrl}/rasters?name__icontains=${searchTerm}&page=${page}`)
+        .get(`${baseUrl}/rasters?name__icontains=${searchTerm}&page=${page}&organisation__name__icontains=${organisationName}`)
         .then(response => {
             dispatch(rastersFetched(response.body))
         })

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -7,7 +7,7 @@ interface MyProps {
     fetchOrganisations: (searchTerm: string) => void,
     observationTypes: ObservationType[],
     organisations: Organisation[],
-    onOrganisationCheckbox: (name: string) => void,
+    onOrganisationCheckbox: (organisation: Organisation) => void,
     fetchRasters: (page: number, searchTerm: string, organisationName: string) => void,
     page: number,
     searchTerm: string,
@@ -18,14 +18,14 @@ interface MyProps {
 interface MyState {
     searchTerm: string,
     obsItems: number,
-    orgItems: number,
+    orgItems: number
 };
 
 class FilterBar extends React.Component<MyProps, MyState> {
     state: MyState = {
         searchTerm: '',
         obsItems: 7,
-        orgItems: 7,
+        orgItems: 7
     };
 
     onChange = (event) => {
@@ -42,9 +42,13 @@ class FilterBar extends React.Component<MyProps, MyState> {
         });
     };
 
-    onClick = (organisationName: string) => {
-        this.props.fetchRasters(this.props.page, this.props.searchTerm, organisationName);
-        this.props.onOrganisationCheckbox(organisationName);
+    onClick = (organisation: Organisation) => {
+        this.props.onOrganisationCheckbox(organisation);
+        
+    };
+
+    onOrganisationCheck = (organisation: Organisation) => {
+        organisation.checked = !organisation.checked
     };
 
     componentDidMount() {
@@ -97,7 +101,7 @@ class FilterBar extends React.Component<MyProps, MyState> {
                         <ul className="filter-list">
                             {organisations.slice(0, this.state.orgItems).map((organisation: Organisation) => (
                                 <li className="filter-item" key={organisation.name}>
-                                    <input type="checkbox" className="filter-checkbox" onClick={() => this.onClick(organisation.name)} />
+                                    <input type="checkbox" className="filter-checkbox" onClick={() => this.onClick(organisation)} onChange={() => this.onOrganisationCheck(organisation)} checked={organisation.checked}/>
                                     <span className="filter-item-name">{organisation.name}</span>
                                 </li>
                             ))}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -6,20 +6,26 @@ interface MyProps {
     fetchObservationTypes: () => void,
     fetchOrganisations: (searchTerm: string) => void,
     observationTypes: ObservationType[],
-    organisations: Organisation[]
+    organisations: Organisation[],
+    onOrganisationCheckbox: (name: string) => void,
+    fetchRasters: (page: number, searchTerm: string, organisationName: string) => void,
+    page: number,
+    searchTerm: string,
+    organisationName: string
+
 };
 
 interface MyState {
     searchTerm: string,
     obsItems: number,
-    orgItems: number
+    orgItems: number,
 };
 
 class FilterBar extends React.Component<MyProps, MyState> {
     state: MyState = {
         searchTerm: '',
         obsItems: 7,
-        orgItems: 7
+        orgItems: 7,
     };
 
     onChange = (event) => {
@@ -34,6 +40,11 @@ class FilterBar extends React.Component<MyProps, MyState> {
         this.setState({
             searchTerm: ''
         });
+    };
+
+    onClick = (organisationName: string) => {
+        this.props.fetchRasters(this.props.page, this.props.searchTerm, organisationName);
+        this.props.onOrganisationCheckbox(organisationName);
     };
 
     componentDidMount() {
@@ -82,7 +93,7 @@ class FilterBar extends React.Component<MyProps, MyState> {
                         <ul className="filter-list">
                             {organisations.slice(0, this.state.orgItems).map((organisation: Organisation) => (
                                 <li className="filter-item" key={organisation.name}>
-                                    <input type="checkbox" className="filter-checkbox" />
+                                    <input type="checkbox" className="filter-checkbox" onClick={() => this.onClick(organisation.name)} />
                                     <span className="filter-item-name">{organisation.name}</span>
                                 </li>
                             ))}

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -85,7 +85,11 @@ class FilterBar extends React.Component<MyProps, MyState> {
                                     <span className="filter-item-name">{observationType.parameter}</span>
                                 </li>
                             ))}
-                            <button className="filter-list-button" onClick={() => this.setState({obsItems: this.state.obsItems + 7})}>more ...</button>
+                            {this.state.obsItems < observationTypes.length ? 
+                                <button className="filter-list-button" onClick={() => this.setState({obsItems: this.state.obsItems + 7})}>more ...</button> :
+                                <button style={{display: 'none'}}/>
+                            }
+                            
                         </ul>
                     </div>
                     <div className="filter-organisation">
@@ -97,7 +101,10 @@ class FilterBar extends React.Component<MyProps, MyState> {
                                     <span className="filter-item-name">{organisation.name}</span>
                                 </li>
                             ))}
-                            <button className="filter-list-button" onClick={() => this.setState({orgItems: this.state.orgItems + 7})}>more ...</button>
+                            {this.state.orgItems < organisations.length ? 
+                                <button className="filter-list-button" onClick={() => this.setState({orgItems: this.state.orgItems + 7})}>more ...</button> :
+                                <button style={{display: 'none'}}/>
+                            }
                         </ul>
                     </div>
                 </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,7 +43,7 @@ class Header extends React.Component<MyProps> {
                         <svg className="header-nav__icon">
                             <use xlinkHref="image/symbols.svg#icon-user" />
                         </svg>
-                        <span className="header-nav__text">Jan de Vries</span>
+                        <span className="header-nav__text">User</span>
                     </div>
                     <div className="header-nav__icon-box">
                         <svg className="header-nav__icon">

--- a/src/components/RasterContainer.tsx
+++ b/src/components/RasterContainer.tsx
@@ -64,18 +64,36 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
     };
 
     //When click on the checkbox in the filter bar, this function will update the organisation name state in this component
-    onOrganisationCheckBox = (name: string) => {
-        this.setState({
-            organisationName: name
-        });
+    onOrganisationCheckBox = (organisation: Organisation) => {
+        if (!organisation.checked) {
+            this.setState({
+                organisationName: organisation.name
+            });
+            this.props.fetchRasters(this.state.page, this.state.searchTerm, organisation.name);
+        } else {
+            this.setState({
+                organisationName: ''
+            });
+            this.props.fetchRasters(this.state.page, this.state.searchTerm, '');
+        }
+        
     };
 
     componentDidMount() {
         this.props.fetchRasters(this.state.page, this.state.searchTerm, this.state.organisationName);
     };
-    
+
+    // componentWillUpdate(nextProps, nextState: MyState) {
+    //     if (nextState.organisationName !== this.state.organisationName) {
+    //         console.log(nextProps.updateBasket)
+    //         console.log(this.state.organisationName)
+    //         console.log(nextState.organisationName)
+    //         this.props.fetchRasters(this.state.page, this.state.searchTerm, nextState.organisationName);
+    //     } 
+    // }
 
     render() {
+        console.log(this.state.organisationName)
         return (
             <div className="raster-container">
                 <div className="raster-header">

--- a/src/components/RasterContainer.tsx
+++ b/src/components/RasterContainer.tsx
@@ -18,7 +18,7 @@ interface PropsFromState {
 
 interface PropsFromDispatch {
     selectRaster: (uuid: string) => void;
-    fetchRasters: (page: number, searchTerm: string) => void;
+    fetchRasters: (page: number, searchTerm: string, organisationName: string) => void;
     updateBasket: (basket) => void;
     fetchObservationTypes: () => void;
     fetchOrganisations: (searchTerm: string) => void;
@@ -30,18 +30,20 @@ interface MyState {
     page: number;
     initialPage: number;
     searchTerm: string;
+    organisationName: string
 };
 
 class RasterContainer extends React.Component<RasterContainerProps, MyState> {
     state: MyState = {
         page: 1,
         initialPage: 1,
-        searchTerm: ''
+        searchTerm: '',
+        organisationName: ''
     };
 
     onClick = (page: number) => {
         if (page < 1) return page = 1;
-        this.props.fetchRasters(page, this.state.searchTerm);
+        this.props.fetchRasters(page, this.state.searchTerm, this.state.organisationName);
         this.setState({
             page: page,
         });
@@ -58,12 +60,20 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
         this.setState({
             page: 1
         });
-        this.props.fetchRasters(this.state.initialPage, this.state.searchTerm);
+        this.props.fetchRasters(this.state.initialPage, this.state.searchTerm, this.state.organisationName);
+    };
+
+    //When click on the checkbox in the filter bar, this function will update the organisation name state in this component
+    onOrganisationCheckBox = (name: string) => {
+        this.setState({
+            organisationName: name
+        });
     };
 
     componentDidMount() {
-        this.props.fetchRasters(this.state.page, this.state.searchTerm);
+        this.props.fetchRasters(this.state.page, this.state.searchTerm, this.state.organisationName);
     };
+    
 
     render() {
         return (
@@ -77,6 +87,11 @@ class RasterContainer extends React.Component<RasterContainerProps, MyState> {
                         observationTypes={this.props.observationTypes}
                         fetchOrganisations={this.props.fetchOrganisations}
                         organisations={this.props.organisations}
+                        onOrganisationCheckbox={this.onOrganisationCheckBox}
+                        fetchRasters={this.props.fetchRasters}
+                        page={this.state.page}
+                        searchTerm={this.state.searchTerm}
+                        organisationName={this.state.organisationName}
                     />
                     <RasterList
                         searchTerm={this.state.searchTerm}
@@ -102,7 +117,7 @@ const mapStateToProps = (state: MyStore): PropsFromState => ({
 });
 
 const mapDispatchToProps = (dispatch: Dispatch<RasterActionType | Basket | FilterActionType>): PropsFromDispatch => ({
-    fetchRasters: (page: number, searchTerm: string) => fetchRasters(page, searchTerm, dispatch),
+    fetchRasters: (page: number, searchTerm: string, organisationName: string) => fetchRasters(page, searchTerm, organisationName, dispatch),
     selectRaster: (uuid: string) => selectRaster(uuid, dispatch),
     updateBasket: (basket) => updateBasket(basket, dispatch),
     fetchObservationTypes: () => fetchObservationTypes(dispatch),

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -75,6 +75,7 @@ export interface Organisation {
     url: string;
     name: string;
     uuid: string;
+    checked: boolean
 };
 
 export interface ObservationType {

--- a/src/reducers.ts
+++ b/src/reducers.ts
@@ -1,6 +1,6 @@
 import { combineReducers } from 'redux';
 import { RASTERS_FETCHED, RASTER_SELECTED, BASKET_UPDATED, OBSERVATION_TYPES_FETCHED, ORGANISATIONS_FETCHED, ITEM_REMOVED } from "./action";
-import { RastersFetched, RasterSelected, Raster, ObservationType, Organisation, Basket } from './interface';
+import { RastersFetched, RasterSelected, Raster, ObservationType, Organisation, Basket, OrganisationsFetched, ObservationTypesFetched } from './interface';
 
 export interface MyStore {
     observationTypes: ObservationType[];
@@ -70,7 +70,7 @@ const basket = (state: MyStore['basket'] = [], action: Basket) => {
     };
 };
 
-const observationTypes = (state: MyStore['observationTypes'] = [], action) => {
+const observationTypes = (state: MyStore['observationTypes'] = [], action: ObservationTypesFetched) => {
     switch (action.type) {
         case OBSERVATION_TYPES_FETCHED:
             return action.payload;
@@ -79,10 +79,17 @@ const observationTypes = (state: MyStore['observationTypes'] = [], action) => {
     };
 };
 
-const organisations = (state: MyStore['organisations'] = [], action) => {
+const organisations = (state: MyStore['organisations'] = [], action: OrganisationsFetched) => {
     switch (action.type) {
         case ORGANISATIONS_FETCHED:
-            return action.payload;
+            return action.payload.map(organisation => {
+                return {
+                    url: organisation.url,
+                    name: organisation.name,
+                    uuid: organisation.uuid,
+                    checked: false
+                };
+            });
         default:
             return state;
     };


### PR DESCRIPTION
Select an organisation in the filter bar will cause the RasterList component to re-render and fetch the new raster list based on the organisation. Uncheck the selection will also cause the RasterList component to re-render and fetch the whole list of rasters again.