### PR TITLE
Fix possible bug when raster.observation_type can possibly be null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # production
 /build
+/deploy
+/dist
 
 # misc
 .DS_Store

--- a/src/components/RasterDetails.tsx
+++ b/src/components/RasterDetails.tsx
@@ -79,10 +79,10 @@ class RasterDetails extends React.Component<PropsFromState> {
                         <p className="column column-1">Observation type</p><p className="column column-2">{raster.observation_type && raster.observation_type.parameter}</p>
                     </div>
                     <div className="row">
-                        <p className="column column-1">Measuring unit</p><p className="column column-2">{raster.observation_type.unit}</p>
+                        <p className="column column-1">Measuring unit</p><p className="column column-2">{raster.observation_type && raster.observation_type.unit}</p>
                     </div>
                     <div className="row">
-                        <p className="column column-1">Scale</p><p className="column column-2">{raster.observation_type.scale}</p>
+                        <p className="column column-1">Scale</p><p className="column column-2">{raster.observation_type && raster.observation_type.scale}</p>
                     </div>
                 </div>
                 <br/>


### PR DESCRIPTION
When running on staging server, raster.observation_type can possibly be null and it causes the app to crash as in the Raster Details component, there are a number of elements using this raster.observation_type object.