### PR TITLE
Use WMS spatial bounds to zoom into the WMS layer

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,7 +5,7 @@ import { removeRasterFromBasket, removeWMSFromBasket } from '../action';
 import { Raster, LatLng, Bootstrap, WMS } from '../interface';
 import './styles/Header.css';
 
-import { zoomLevelCalculation, getCenterPoint } from '../utils/latLngZoomCalculation';
+import { zoomLevelCalculation, getCenterPoint, getBounds } from '../utils/latLngZoomCalculation';
 import { openAllInLizard } from '../utils/url';
 
 interface MyProps {
@@ -30,18 +30,27 @@ class Header extends React.Component<HeaderProps> {
     //Open All Data button will open all rasters and WMS layers in Lizard Client
     //with projection of the last selected raster
     openInLizard = (rasters: Raster[], wmsLayers: WMS[]) => {
-        //Get the last selected raster in the basket which is the first item in the rasters array
-        const lastSelectedRaster = rasters.length !== 0 ? rasters[0] : null;
+        //Get the last selected raster in the basket or last selected WMS layer if there is no raster
+        let lastSelectedObject: Raster | WMS | null = null;
 
-        //Get the spatial bounds of the last selected raster, if spatial_bounds is null then set it to the global map
-        const { north, east, south, west } = (lastSelectedRaster && lastSelectedRaster.spatial_bounds) ?
-            lastSelectedRaster.spatial_bounds : { north: 85, east: 180, south: -85, west: -180 };
+        //The first item in the rasters/WMS layers array is the last selected object
+        if (rasters.length > 0) {
+            lastSelectedObject = rasters[0];
+        } else if (wmsLayers.length > 0) {
+            lastSelectedObject = wmsLayers[0];
+        };
+
+        //Get the spatial bounds of the last selected object,
+        //if lastSelectedObject is null then set it to the global map
+        const bounds = lastSelectedObject ? getBounds(lastSelectedObject) : {
+            north: 85, east: 180, south: -85, west: -180
+        };
 
         //Get the center point of the raster based on its spatial bounds
-        const centerPoint: LatLng = getCenterPoint(north, east, south, west);
+        const centerPoint: LatLng = getCenterPoint(bounds);
 
         //Calculate the zoom level of the last selected raster by using the zoomLevelCalculation function
-        const zoom = zoomLevelCalculation(north, east, south, west);
+        const zoom = zoomLevelCalculation(bounds);
 
         //Open all rasters and WMS layers in Lizard
         openAllInLizard(rasters, centerPoint, zoom, wmsLayers);

--- a/src/components/rasters/RasterDetails.tsx
+++ b/src/components/rasters/RasterDetails.tsx
@@ -5,7 +5,7 @@ import { MyStore, getRaster } from '../../reducers';
 import { Raster, LatLng } from '../../interface';
 import '../styles/Details.css';
 
-import { zoomLevelCalculation, getCenterPoint } from '../../utils/latLngZoomCalculation';
+import { zoomLevelCalculation, getCenterPoint, getBounds, boundsToDisplay } from '../../utils/latLngZoomCalculation';
 import { openRasterInAPI, openRasterInLizard } from '../../utils/url';
 
 interface PropsFromState {
@@ -21,17 +21,14 @@ class RasterDetails extends React.Component<PropsFromState> {
         if (!raster) return <div className="details details__loading">Please select a raster</div>;
 
         //Set the Map with bounds coming from spatial_bounds of the Raster
-        //If spatial_bounds is null then set the projection to the whole globe which is at [[85, 180], [-85, -180]]
-        const { north, east, south, west } = raster.spatial_bounds ?
-            raster.spatial_bounds : { north: 85, east: 180, south: -85, west: -180 };
-
-        const bounds = [[north, east], [south, west]];
+        const rasterBounds = getBounds(raster);
+        const bounds = boundsToDisplay(rasterBounds);
 
         //Get the center point of the raster based on its spatial bounds
-        const centerPoint: LatLng = getCenterPoint(north, east, south, west);
+        const centerPoint: LatLng = getCenterPoint(rasterBounds);
 
         //Calculate the zoom level of the raster by using the zoomLevelCalculation function
-        const zoom = zoomLevelCalculation(north, east, south, west);
+        const zoom = zoomLevelCalculation(rasterBounds);
 
         //Get the Date from the timestamp string
         const lastestUpdateDate = new Date(raster.last_modified);

--- a/src/components/wms/WMSDetails.tsx
+++ b/src/components/wms/WMSDetails.tsx
@@ -2,9 +2,11 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Map, TileLayer, WMSTileLayer } from 'react-leaflet';
 import { MyStore, getWMS } from '../../reducers';
-import { WMS } from '../../interface';
+import { WMS, LatLng } from '../../interface';
 import '../styles/Details.css';
+
 import { openWMSInAPI, openWMSInLizard, openWMSDownloadURL } from '../../utils/url';
+import { getCenterPoint, zoomLevelCalculation, getBounds, boundsToDisplay } from '../../utils/latLngZoomCalculation';
 
 interface PropsFromState {
     wms: WMS | null
@@ -17,6 +19,16 @@ class WMSDetails extends React.Component<PropsFromState> {
 
         //If no WMS layer is selected, display a text
         if (!wms) return <div className="details details__loading">Please select a WMS Layer</div>;
+
+        //Get spatial bounds of the WMS layer
+        const wmsBounds = getBounds(wms);
+        const bounds = boundsToDisplay(wmsBounds);
+
+        //Get the center point of the raster based on its spatial bounds
+        const centerPoint: LatLng = getCenterPoint(wmsBounds);
+
+        //Calculate the zoom level of the raster by using the zoomLevelCalculation function
+        const zoom = zoomLevelCalculation(wmsBounds);
 
         return (
             <div className="details">
@@ -36,7 +48,7 @@ class WMSDetails extends React.Component<PropsFromState> {
                         <span>{wms.dataset && wms.dataset[0]}</span>
                     </div>
                     <div className="details__map-box">
-                        <Map center={[0,0]} zoom={wms.min_zoom} zoomControl={false}>
+                        <Map bounds={bounds} zoom={wms.min_zoom} zoomControl={false}>
                             <TileLayer url="https://{s}.tiles.mapbox.com/v3/nelenschuurmans.iaa98k8k/{z}/{x}/{y}.png" />
                             {wms.wms_url ? <WMSTileLayer
                                 url={wms.wms_url}
@@ -59,7 +71,7 @@ class WMSDetails extends React.Component<PropsFromState> {
                 <div className="details__button-container">
                     <h4>Actions</h4><hr/>
                     <div className="details__buttons">
-                        <button className="details__button" onClick={() => openWMSInLizard(wms)} title="Open in Portal">
+                        <button className="details__button" onClick={() => openWMSInLizard(wms, centerPoint, zoom)} title="Open in Portal">
                             <i className="fa fa-external-link"/>
                             &nbsp;&nbsp;OPEN IN PORTAL
                         </button>

--- a/src/utils/latLngZoomCalculation.ts
+++ b/src/utils/latLngZoomCalculation.ts
@@ -1,21 +1,38 @@
 import * as L from 'leaflet';
+import { Raster, WMS } from '../interface';
 
-//Determine the Lat and Long of the center point of the raster on the map
-export const getCenterPoint = (north: number, east: number, south: number, west: number) => {
-    const bounds = L.latLngBounds([north, east], [south, west]);
-    return bounds.getCenter();
+//Determine the Lat and Long of the center point of the raster/WMS layer on the map
+export const getCenterPoint = (bounds: Raster['spatial_bounds']) => {
+    const { north, east, south, west } = bounds;
+    const spatialBounds = L.latLngBounds([north, east], [south, west]);
+    return spatialBounds.getCenter();
 };
 
-//Get the zoom level based on 4 spatial bounds
+//Get the zoom level based on spatial bounds
 //Get reference from stackoverflow on how to calculate the zoom level: 
 //https://stackoverflow.com/questions/6048975/google-maps-v3-how-to-calculate-the-zoom-level-for-a-given-bounds
-export const zoomLevelCalculation = (north: number, east: number, south: number, west: number) => {
-
+export const zoomLevelCalculation = (bounds: Raster['spatial_bounds']) => {
+    const { north, east, south, west } = bounds;
     const GLOBE_WIDTH = 256; //a constant in Google's map projection
     let angle = east - west;
     if (angle < 0) angle += 360;
     let angle2 = north - south;
     if (angle2 > angle) angle = angle2;
-
     return Math.round(Math.log(960 * 360 / angle / GLOBE_WIDTH) / Math.LN2);
+};
+
+//Get spatial bounds for the raster/WMS layer
+export const getBounds = (object: Raster | WMS) => {
+    //If spatial_bounds is null then set the projection
+    //to the whole globe which is at [[85, 180], [-85, -180]]
+    const bounds = object.spatial_bounds ? object.spatial_bounds : {
+        north: 85, east: 180, south: -85, west: -180
+    };
+    return bounds;
+};
+
+//Get the bounds format to display on the map as [[north, east], [south, west]]
+export const boundsToDisplay = (bounds: Raster['spatial_bounds']) => {
+    const { north, east, south, west } = bounds;
+    return [[north, east], [south, west]];
 };

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -15,11 +15,11 @@ export const openRasterInLizard = (raster: Raster, centerPoint: LatLng, zoom: nu
     window.open(`/nl/map/topography,raster$${rasterShortUUID}/point/@${centerPoint.lat},${centerPoint.lng},${zoom}`);
 };
 
-export const openWMSInLizard = (wms: WMS) => {
+export const openWMSInLizard = (wms: WMS, centerPoint: LatLng, zoom: number) => {
     //create short UUID of the WMS layer
     const wmsShortUUID = wms.uuid.substr(0, 7);
 
-    window.open(`/nl/map/topography,wmslayer$${wmsShortUUID}`);
+    window.open(`/nl/map/topography,wmslayer$${wmsShortUUID}/point/@${centerPoint.lat},${centerPoint.lng},${zoom}`);
 };
 
 export const openAllInLizard = (rasters: Raster[], centerPoint: LatLng, zoom: number, wmsLayers: WMS[]) => {


### PR DESCRIPTION
- When click on an WMS, it will zoom into the WMS layer in map preview and also when open the WMS layer in Lizard Portal if the WMS layer has spatial bounds defined.
- Also refactor functions to get the bounds, center points and zoom level.