### PR TITLE
Clickable labels

### DIFF
--- a/src/components/FilterOption.tsx
+++ b/src/components/FilterOption.tsx
@@ -110,11 +110,12 @@ const FilterOption: React.FC<MyProps> = (props) => {
                         <li className={styles.FilterItem} key={i}>
                             <input
                                 type="radio"
+                                id={getItemValue(item, filterOption)}
                                 className={styles.FilterRadioButton}
                                 onChange={() => selectItem(getItemValue(item, filterOption))}
                                 checked={filterValue === getItemValue(item, filterOption)}
                             />
-                            <label className={styles.FilterItemName}>{getItemValue(item, filterOption)}</label>
+                            <label htmlFor={getItemValue(item, filterOption)} className={styles.FilterItemName}>{getItemValue(item, filterOption)}</label>
                         </li>
                     ))}
                     {numberOfItems < filteredListOfItems.length ? (


### PR DESCRIPTION
While watching consultants use the catalog, I noticed they had some trouble clicking on the exact radio buttons to select filter items. This PR solves that by making the labels clickable using the htmlFor attribute.

This PR:
- Adds `htmlFor` and an `id` to the filter list items

Demo:
![labels-clicking](https://user-images.githubusercontent.com/7193/200296098-00df0e6c-224b-4c5b-a27f-e267252f468a.gif)
